### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,6 @@
 name: Lint
+permissions:
+  contents: read
 on:
   pull_request:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/cimcai/cimcai.github.io/security/code-scanning/1](https://github.com/cimcai/cimcai.github.io/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. Since the workflow only performs linting and does not require write access to the repository or other GitHub features, we will set `contents: read` as the minimal permission. This ensures the workflow has only the permissions it needs to function correctly.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
